### PR TITLE
feat: declare unsafe_code as forbidden

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(nightly, feature(doc_cfg))]
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 
 //! Semi-hierarchical configuration so con-free, it's unreal.
 //!


### PR DESCRIPTION
Supporting the geiger counter ([cargo-geiger](https://github.com/rust-secure-code/cargo-geiger)), decalring unsafe as forbidden rust should be a pest practices if there is not intent or use of `unsafe`